### PR TITLE
Handling "SERVER_STOPPED" message from server

### DIFF
--- a/src/main/java/fr/utc/onzzer/client/communication/impl/ClientCommunicationController.java
+++ b/src/main/java/fr/utc/onzzer/client/communication/impl/ClientCommunicationController.java
@@ -73,10 +73,20 @@ public class ClientCommunicationController implements ComMainServices, ComMusicS
                 TrackLite trackLite = (TrackLite) message.object;
                 this.clientRequestHandler.publishTrack(trackLite);
             }
+            case SERVER_STOPPED -> {
+                System.out.println("Received message indicating the server has stopped.");
+                this.clientRequestHandler.serverStopped();
+            }
 
             default ->
                     System.out.println("Unhandled message");
         }
+
+        /* To be used when replacing switch case with hashmap
+        messageHandlers.put(SocketMessagesTypes.SERVER_STOPPED, (message, sender) -> {
+            ClientRequestHandler.serverStopped(message, sender);
+        });
+         */
     }
 
     public void sendServer(SocketMessagesTypes messageType, Serializable object) {

--- a/src/main/java/fr/utc/onzzer/client/communication/impl/ClientRequestHandler.java
+++ b/src/main/java/fr/utc/onzzer/client/communication/impl/ClientRequestHandler.java
@@ -29,4 +29,9 @@ public class ClientRequestHandler {
     void publishTrack(final TrackLite trackLite) {
 //        this.dataServicesProvider.getDataTrackServices().addTrack(trackLite);
     }
+
+    void serverStopped() {
+        //TODO disconnect client from server (to be discussed with HMI-Main in order to display a popup)
+        System.out.println("I am executing serverStopped method");
+    }
 }


### PR DESCRIPTION
 + Added case "SERVER_STOPPED" in "onMessage" method For now, it only outputs a message in the console, indicating that a "SERVER_STOPPED" message was received ClientRequestHandler:
 + Added "serverStopped" method For now, it only outputs a message in the console. To be discussed with HMI-Main to display a popup