### PR TITLE
Maven on git

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @CesarDieudonneUTC @FrenchGithubUser @tizba @ThomasDelp @yvesarrata @chevremaudite @Syr0ws @loslcrd @ValentinFagnet @itrider-gh
+* @CesarDieudonneUTC @FrenchGithubUser @tizba @ThomasDelp @yvesarrata @chevremaudite @Syr0ws @loslcrd @ValentinFagnet @itrider-gh @ilianAZZ

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,13 @@
         <junit.version>5.9.2</junit.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.openjfx</groupId>
@@ -39,10 +46,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fr.utc.onzzer</groupId>
+            <groupId>com.github.UTCAI12</groupId>
             <artifactId>onzzer-common</artifactId>
-            <version>1.0.0</version>
-            <scope>compile</scope>
+            <version>dev-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Using jitpack to import onzzer-common
no longer needed to update the local maven cache folder