### PR TITLE
Handling "SERVER_STOPPED" message

### DIFF
--- a/src/main/java/fr/utc/onzzer/client/communication/impl/ClientCommunicationController.java
+++ b/src/main/java/fr/utc/onzzer/client/communication/impl/ClientCommunicationController.java
@@ -63,6 +63,10 @@ public class ClientCommunicationController implements ComMainServices, ComMusicS
             TrackLite trackLite = (TrackLite) message.object;
             this.clientRequestHandler.publishTrack(trackLite);
         });
+        messageHandlers.put(SocketMessagesTypes.SERVER_STOPPED, (message, sender) -> {
+            System.out.println("I have received a SERVER_STOPPED message from server!");
+            this.clientRequestHandler.serverStopped();
+        });
 
         try  {
             this.socket =  new Socket(serverAddress, serverPort);

--- a/src/main/java/fr/utc/onzzer/client/communication/impl/ClientRequestHandler.java
+++ b/src/main/java/fr/utc/onzzer/client/communication/impl/ClientRequestHandler.java
@@ -29,4 +29,9 @@ public class ClientRequestHandler {
     void publishTrack(final TrackLite trackLite) {
 //        this.dataServicesProvider.getDataTrackServices().addTrack(trackLite);
     }
+
+    void serverStopped(){
+        // TODO a popup should be added to warn the user that the server stopped. To be discussed with HMI-main
+        System.out.println("I am executing serverStopped method.");
+    }
 }


### PR DESCRIPTION
ClientCommunicationController:
 + Added handler "SERVER_STOPPED" in messageHandlers attribute
For now, it only outputs a message in the console, indicating that a "SERVER_STOPPED" message was received
ClientRequestHandler:
 + Added "serverStopped" method
 For now, it only outputs a message in the console. To be discussed with HMI-Main to display a popup

